### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
 
   def index
+    @items = Item.all  
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
 
   def index
-    @items = Item.all  
+    @items = Item.all
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,6 @@
 class Item < ApplicationRecord
   belongs_to :user
-  #has_one :order
+  # has_one :order
   has_one_attached :image
 
   extend ActiveHash::Associations::ActiveRecordExtensions

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,41 +123,43 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <div class="subtitle" >
-      新規投稿商品
-    </div>
+    <%= link_to '新規投稿商品', "#", class: "subtitle" %> 
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% if @items.present? %>
+    <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag (item.image), class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
+          </div>         
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item_name  %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shippingfees.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
-        <% end %>
+       <% end %>
       </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+        <% else %>
       <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
         <%= link_to '#' do %>
@@ -176,6 +178,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,7 +126,7 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %> 
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      
     <% if @items.present? %>
     <% @items.each do |item| %>
       <li class='list'>
@@ -135,9 +135,9 @@
           <%= image_tag (item.image), class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+         <%# <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>         
+          </div> %>        
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
@@ -155,12 +155,9 @@
         </div>
        <% end %>
       </li>
-      <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>   
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-        <% else %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+        <% else %>   
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -178,9 +175,7 @@
         </div>
         <% end %>
       </li>
-      <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>   
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Item, type: :model do
       @item.prefecture_id = '0'
       @item.valid?
       expect(@item.errors.full_messages).to include("Prefecture can't be blank")
-    end    
+    end
     it '発送日までのid:1では出品できない' do
       @item.delivery_id = '1'
       @item.valid?
@@ -72,17 +72,17 @@ RSpec.describe Item, type: :model do
     it '販売価格は、¥300~¥9,999,999の間のみ保存可能であること' do
       @item.price = '100'
       @item.valid?
-      expect(@item.errors.full_messages).to include('Price is out of setting range')      
+      expect(@item.errors.full_messages).to include('Price is out of setting range')
     end
     it '販売価格は、10000000以上の値では保存できないこと' do
-    @item.price = '10000000'
-    @item.valid?
-    expect(@item.errors.full_messages).to include('Price is out of setting range')
+      @item.price = '10000000'
+      @item.valid?
+      expect(@item.errors.full_messages).to include('Price is out of setting range')
     end
     it 'userが紐づいていないと保存できない' do
-    @item.user = nil
-    @item.valid?
-    expect(@item.errors.full_messages).to include('User must exist')
+      @item.user = nil
+      @item.valid?
+      expect(@item.errors.full_messages).to include('User must exist')
     end
   end
 end


### PR DESCRIPTION
# What
商品一覧表示機能の実装

# Why
出品された商品がトップページで表示されるようにするため
（sold outの文字はコメントアウトしています）

# gyazo
商品のデータがない場合はダミー商品が表示されている動画
https://gyazo.com/510aacc280c6c8f059f957f8d6e62fbd

商品のデータがある場合は商品が一覧で表示されている動画
https://gyazo.com/2ee8dfb99f36875836da01942b26b809